### PR TITLE
fix memory leak problem of vector

### DIFF
--- a/examples/mnist/include/mnist_helper.h
+++ b/examples/mnist/include/mnist_helper.h
@@ -4,6 +4,7 @@
 #include <cstring>
 #include <cassert>
 #include <vector>
+#include <algorithm>
 
 typedef float Dtype;
 
@@ -17,6 +18,7 @@ void LoadRaw(const char* f_image, const char* f_label, std::vector< Dtype* >& im
     num = __builtin_bswap32(num); // the raw data is high endian    
     assert(fread(&buf, sizeof(int), 1, fid) == 1); // rows 
     assert(fread(&buf, sizeof(int), 1, fid) == 1); // cols
+    std::for_each(images.begin(), images.end(), [](Dtype*& val) {delete val;});
     images.clear();    
     unsigned char* buffer = new unsigned char[784];
     for (int i = 0; i < num; ++i)

--- a/examples/mnist/include/mnist_helper.h
+++ b/examples/mnist/include/mnist_helper.h
@@ -1,10 +1,10 @@
 #ifndef MNIST_HELPER_H
 #define MNIST_HELPER_H
 
+#include <algorithm>
 #include <cstring>
 #include <cassert>
 #include <vector>
-#include <algorithm>
 
 typedef float Dtype;
 


### PR DESCRIPTION
We cannot directly clear vector of pointers. Memory should be deallocated first.